### PR TITLE
Feature/bump up rails 8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ group :test do
   gem 'pry'
   gem 'pry-byebug'
   gem 'pry-stack_explorer'
-  gem 'mocha'
   gem 'rails', "~> 8.0"
   gem 'mysql2'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,6 @@ group :test do
   gem 'pry-byebug'
   gem 'pry-stack_explorer'
   gem 'mocha'
-  gem 'rails', "~> 7.2"
+  gem 'rails', "~> 8.0"
   gem 'mysql2'
 end

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -706,12 +706,18 @@ module ActiveResource
         merged
       end
 
+      # NOTE: Rails 8.0부터 class_attribute 구현이 바뀌게 됨 (e.g. self.element_name = 'foo' 는 __class_attr_element_name 이라는 private method에 저장됨)
+      # 따라서 기존 메소드를 aliasing 하여 이 값이 있을 경우 그 값을 early return 하여 처리한다.
+      # 참고로 8.0 미만 버전에서는 self.element_name = 'foo' 로 설정했을 경우 아래 메소드가 무시되고 class_attribute에서 meta programming 된 메소드로 처리된다.
+      alias_method :orig_element_name, :element_name
       def element_name
+        return orig_element_name if orig_element_name.present?
         @element_name ||= model_name.element
       end
 
-
+      alias_method :orig_collection_name, :collection_name
       def collection_name
+        return orig_collection_name if orig_collection_name.present?
         @collection_name ||= ActiveSupport::Inflector.pluralize(element_name)
       end
 

--- a/test/cases/base_errors_test.rb
+++ b/test/cases/base_errors_test.rb
@@ -5,7 +5,6 @@ require "fixtures/person"
 
 class BaseErrorsTest < ActiveSupport::TestCase
   def setup
-    binding.pry if ActiveResource::Base.logger.nil?
     ActiveResource::HttpMock.respond_to do |mock|
       mock.post "/people.xml", {}, %q(<?xml version="1.0" encoding="UTF-8"?><errors><error>Age can't be blank</error><error>Known attribute can't be blank</error><error>Name can't be blank</error><error>Name must start with a letter</error><error>Person quota full for today.</error><error>Phone work can't be blank</error><error>Phone is not valid</error></errors>), 422, "Content-Type" => "application/xml; charset=utf-8"
       mock.post "/people.json", {}, %q({"errors":{"age":["can't be blank"],"known_attribute":["can't be blank"],"name":["can't be blank", "must start with a letter"],"person":["quota full for today."],"phone_work":["can't be blank"],"phone":["is not valid"]}}), 422, "Content-Type" => "application/json; charset=utf-8"

--- a/test/cases/callbacks_test.rb
+++ b/test/cases/callbacks_test.rb
@@ -46,7 +46,6 @@ end
 
 class CallbacksTest < ActiveSupport::TestCase
   def setup
-    binding.pry if ActiveResource::Base.logger.nil?
     @developer_attrs = { id: 1, name: "Guillermo", salary: 100_000 }
     @developer = { "developer" => @developer_attrs }.to_json
     ActiveResource::HttpMock.respond_to do |mock|


### PR DESCRIPTION
### 개요
- rails 8.0 버전 업그레이드
- element_name, collection_name 구현 수정

### 주요 변경 사항
- 8.0부터 class_attribute 구현이 일부 바뀌게 되어서 class_attribute로 선언한 이름으로 또 다시 class method를 만들 때 주의해야 함
- Springbank::PlanRelation은 element_name이 "plan_relation"으로 설정되어 있음 ([소스코드](https://github.com/frograms/springbank-rb/blob/08e2de119cce8c8308f7f7d722be48d0eb88405a/lib/springbank/resources/plan_relation.rb#L4))
- 하지만 Springbank::PlanRelation.element_name은 설정된 위 값을 바라보지 못하고 [class method로 구현된 메소드](https://github.com/frograms/activeresource/blob/29b9c85a1c7e06ead783b0725408c2e434562e4d/lib/active_resource/base.rb#L709-L711)를 보게 됨
- 이로 인해 Springbank::PlanRelation::Order는 의도된 값("plan_relation")이 아닌 class method로 실행된 값("order")으로 떨어지게 됨
- 아래는 두 사진은 rails 7.2(ale)와 rails.8.0(brewmaster)에서 실행했을 때 결과임

1. ale
<img width="842" alt="image" src="https://github.com/user-attachments/assets/2ca65632-0dbc-41a7-b9d0-dd428aeb2bd8" />
2. brewmaster
<img width="842" alt="image" src="https://github.com/user-attachments/assets/68e6029f-49ed-43c1-a1b1-64ead599af6c" />

### 참고
- class_attribute 소스코드
  - [8.0.2](https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/activesupport/lib/active_support/core_ext/class/attribute.rb#L86-L135)
  - [7.2.2.1](https://github.com/rails/rails/blob/33beb0a38db1c058123a8e3cc298cad918adfe32/activesupport/lib/active_support/core_ext/class/attribute.rb#L85-L131)